### PR TITLE
adds timeout error as treatable

### DIFF
--- a/src/Record.php
+++ b/src/Record.php
@@ -13,6 +13,7 @@ class Record
      */
     const KAFKA_ERROR_WHITELIST = [
         RD_KAFKA_RESP_ERR__PARTITION_EOF,
+        RD_KAFKA_RESP_ERR__TIMED_OUT,
     ];
 
     /**


### PR DESCRIPTION
while consuming some topic, the consumer has a timeout to end each loop and go for the next one.
when this occurs, its send a Kafka error message, that should be treat as a warning and not failed in the exception handler