### PR TITLE
Enable High Performance for Kafka

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "php": ">=7.1",
         "ext-rdkafka": "*",
         "ext-json": "*",
+        "ext-pcntl": "*",
         "illuminate/support": "~5.5.0|~5.6.0",
         "illuminate/console": "~5.5.0|~5.6.0",
         "illuminate/config": "~5.5.0|~5.6.0"

--- a/config/kafka.php
+++ b/config/kafka.php
@@ -60,6 +60,7 @@ return [
         'default' => [
             'topic' => 'default',
             'broker' => 'default',
+            'high-performance' =>  false,
             'consumer-groups' => [
                 'default' => [
                     'offset-reset' => 'largest',

--- a/config/kafka.php
+++ b/config/kafka.php
@@ -60,7 +60,7 @@ return [
         'default' => [
             'topic' => 'default',
             'broker' => 'default',
-            'high-performance' =>  false,
+            'high-performance' => false,
             'consumer-groups' => [
                 'default' => [
                     'offset-reset' => 'largest',

--- a/src/Authentication/Authentication.php
+++ b/src/Authentication/Authentication.php
@@ -5,5 +5,5 @@ use RdKafka\Conf;
 
 interface Authentication
 {
-    public function authenticate(Conf $conf);
+    public function setAuthentication(Conf $conf);
 }

--- a/src/Authentication/NoAuthentication.php
+++ b/src/Authentication/NoAuthentication.php
@@ -5,7 +5,7 @@ use RdKafka\Conf;
 
 class NoAuthentication implements Authentication
 {
-    public function authenticate(Conf $conf)
+    public function setAuthentication(Conf $conf)
     {
     }
 }

--- a/src/Authentication/SSLAuthentication.php
+++ b/src/Authentication/SSLAuthentication.php
@@ -19,7 +19,7 @@ class SSLAuthentication implements Authentication
         $this->key = $authConfig['key'] ?? null;
     }
 
-    public function authenticate(Conf $conf)
+    public function setAuthentication(Conf $conf)
     {
         $this->validate();
 

--- a/src/Broker.php
+++ b/src/Broker.php
@@ -23,9 +23,9 @@ class Broker
         $this->setAuthentication($authentication);
     }
 
-    public function authenticate(Conf $conf): void
+    public function prepareAuthentication(Conf $conf): void
     {
-        $this->authentication->authenticate($conf);
+        $this->authentication->setAuthentication($conf);
     }
 
     public function getConnections(): string

--- a/src/Config/AbstractConfig.php
+++ b/src/Config/AbstractConfig.php
@@ -34,7 +34,7 @@ abstract class AbstractConfig
         $topicConfig = $this->getTopicConfig($topic);
         $this->setGlobalMiddlewares();
         $this->setTopic($topicConfig);
-        $this->setHighPerformanceConfig();
+        $this->setHighPerformanceConfig($topic);
         $this->setBroker($broker ?: $topicConfig['broker']);
     }
 
@@ -58,9 +58,9 @@ abstract class AbstractConfig
         return $this->enableHighPerformance;
     }
 
-    protected function setHighPerformanceConfig(): void
+    protected function setHighPerformanceConfig(string $topic): void
     {
-        $highPerformance = (bool) config("kafka.{$this->getTopic()}.high-performance", true);
+        $highPerformance = (bool) config("kafka.topics.{$topic}.high-performance", true);
         $this->enableHighPerformance = $highPerformance;
     }
 

--- a/src/Config/AbstractConfig.php
+++ b/src/Config/AbstractConfig.php
@@ -20,6 +20,11 @@ abstract class AbstractConfig
     protected $broker;
 
     /**
+     * @var bool
+     */
+    protected $enableHighPerformance;
+
+    /**
      * @var iterable
      */
     protected $middlewares = [];
@@ -29,6 +34,7 @@ abstract class AbstractConfig
         $topicConfig = $this->getTopicConfig($topic);
         $this->setGlobalMiddlewares();
         $this->setTopic($topicConfig);
+        $this->setHighPerformanceConfig();
         $this->setBroker($broker ?: $topicConfig['broker']);
     }
 
@@ -45,6 +51,17 @@ abstract class AbstractConfig
     public function getMiddlewares(): iterable
     {
         return $this->middlewares;
+    }
+
+    public function enableHighPerformance(): bool
+    {
+        return $this->enableHighPerformance;
+    }
+
+    protected function setHighPerformanceConfig(): void
+    {
+        $highPerformance = (bool) config("kafka.{$this->getTopic()}.high-performance", true);
+        $this->enableHighPerformance = $highPerformance;
     }
 
     protected function getTopicConfig(string $topic): array

--- a/src/Config/AbstractConfig.php
+++ b/src/Config/AbstractConfig.php
@@ -53,7 +53,7 @@ abstract class AbstractConfig
         return $this->middlewares;
     }
 
-    public function enableHighPerformance(): bool
+    public function isHighPerformanceEnabled(): bool
     {
         return $this->enableHighPerformance;
     }

--- a/src/Config/Producer.php
+++ b/src/Config/Producer.php
@@ -9,7 +9,7 @@ class Producer extends AbstractConfig
     /**
      * @var int
      */
-    protected $timeoutResponses = 50;
+    protected $timeoutResponses = 1;
 
     public function __construct(string $topic)
     {

--- a/src/Connectors/AbstractConnector.php
+++ b/src/Connectors/AbstractConnector.php
@@ -20,7 +20,7 @@ abstract class AbstractConnector
 
         $broker->prepareAuthentication($conf);
 
-        if ($config->enableHighPerformance()) {
+        if ($config->isHighPerformanceEnabled()) {
             $this->setHighPerformance($conf);
         }
 

--- a/src/Connectors/AbstractConnector.php
+++ b/src/Connectors/AbstractConnector.php
@@ -12,7 +12,7 @@ abstract class AbstractConnector
      */
     protected $config;
 
-    protected function getConf(Broker $broker): Conf
+    protected function getDefaultConf(Broker $broker): Conf
     {
         $conf = resolve(Conf::class);
 

--- a/src/Connectors/AbstractConnector.php
+++ b/src/Connectors/AbstractConnector.php
@@ -20,6 +20,16 @@ abstract class AbstractConnector
 
         $broker->prepareAuthentication($conf);
 
+        $this->setHighPerformance($conf);
+
         return $conf;
+    }
+
+    protected function setHighPerformance(Conf $conf): void
+    {
+        $conf->set('socket.timeout.ms', 50);
+
+        pcntl_sigprocmask(SIG_BLOCK, [SIGIO]);
+        $conf->set('internal.termination.signal', SIGIO);
     }
 }

--- a/src/Connectors/AbstractConnector.php
+++ b/src/Connectors/AbstractConnector.php
@@ -1,7 +1,6 @@
 <?php
 namespace Metamorphosis\Connectors;
 
-use Metamorphosis\Broker;
 use Metamorphosis\Config\AbstractConfig;
 use RdKafka\Conf;
 
@@ -12,15 +11,18 @@ abstract class AbstractConnector
      */
     protected $config;
 
-    protected function getDefaultConf(Broker $broker): Conf
+    protected function getDefaultConf(AbstractConfig $config): Conf
     {
         $conf = resolve(Conf::class);
+        $broker = $config->getBrokerConfig();
 
         $conf->set('metadata.broker.list', $broker->getConnections());
 
         $broker->prepareAuthentication($conf);
 
-        $this->setHighPerformance($conf);
+        if ($config->enableHighPerformance()) {
+            $this->setHighPerformance($conf);
+        }
 
         return $conf;
     }

--- a/src/Connectors/AbstractConnector.php
+++ b/src/Connectors/AbstractConnector.php
@@ -1,0 +1,25 @@
+<?php
+namespace Metamorphosis\Connectors;
+
+use Metamorphosis\Broker;
+use RdKafka\Conf;
+use Metamorphosis\Config\AbstractConfig;
+
+abstract class AbstractConnector
+{
+    /**
+     * @var AbstractConfig
+     */
+    protected $config;
+
+    protected function getConf(Broker $broker): Conf
+    {
+        $conf = resolve(Conf::class);
+
+        $conf->set('metadata.broker.list', $broker->getConnections());
+
+        $broker->prepareAuthentication($conf);
+
+        return $conf;
+    }
+}

--- a/src/Connectors/AbstractConnector.php
+++ b/src/Connectors/AbstractConnector.php
@@ -2,8 +2,8 @@
 namespace Metamorphosis\Connectors;
 
 use Metamorphosis\Broker;
-use RdKafka\Conf;
 use Metamorphosis\Config\AbstractConfig;
+use RdKafka\Conf;
 
 abstract class AbstractConnector
 {

--- a/src/Connectors/Consumer/HighLevel.php
+++ b/src/Connectors/Consumer/HighLevel.php
@@ -17,7 +17,7 @@ class HighLevel extends AbstractConnector implements ConnectorInterface
     public function getConsumer(): ConsumerInterface
     {
         $broker = $this->config->getBrokerConfig();
-        $conf = $this->getConf($broker);
+        $conf = $this->getDefaultConf($broker);
 
         $conf->set('group.id', $this->config->getConsumerGroupId());
         $conf->set('auto.offset.reset', $this->config->getConsumerOffsetReset());

--- a/src/Connectors/Consumer/HighLevel.php
+++ b/src/Connectors/Consumer/HighLevel.php
@@ -1,27 +1,23 @@
 <?php
 namespace Metamorphosis\Connectors\Consumer;
 
-use Metamorphosis\Config\Consumer;
+use Metamorphosis\Config\Consumer as ConfigConsumer;
+use Metamorphosis\Connectors\AbstractConnector;
 use Metamorphosis\Consumers\ConsumerInterface;
 use Metamorphosis\Consumers\HighLevel as HighLevelConsumer;
-use RdKafka\Conf;
 use RdKafka\KafkaConsumer;
 
-class HighLevel implements ConnectorInterface
+class HighLevel extends AbstractConnector implements ConnectorInterface
 {
-    /**
-     * @var Consumer
-     */
-    protected $config;
-
-    public function __construct(Consumer $config)
+    public function __construct(ConfigConsumer $config)
     {
         $this->config = $config;
     }
 
     public function getConsumer(): ConsumerInterface
     {
-        $conf = $this->getConf();
+        $broker = $this->config->getBrokerConfig();
+        $conf = $this->getConf($broker);
 
         $conf->set('group.id', $this->config->getConsumerGroupId());
         $conf->set('auto.offset.reset', $this->config->getConsumerOffsetReset());
@@ -30,18 +26,5 @@ class HighLevel implements ConnectorInterface
         $consumer->subscribe([$this->config->getTopic()]);
 
         return new HighLevelConsumer($consumer);
-    }
-
-    protected function getConf(): Conf
-    {
-        $broker = $this->config->getBrokerConfig();
-
-        $conf = resolve(Conf::class);
-
-        $conf->set('metadata.broker.list', $broker->getConnections());
-
-        $broker->authenticate($conf);
-
-        return $conf;
     }
 }

--- a/src/Connectors/Consumer/HighLevel.php
+++ b/src/Connectors/Consumer/HighLevel.php
@@ -16,8 +16,7 @@ class HighLevel extends AbstractConnector implements ConnectorInterface
 
     public function getConsumer(): ConsumerInterface
     {
-        $broker = $this->config->getBrokerConfig();
-        $conf = $this->getDefaultConf($broker);
+        $conf = $this->getDefaultConf($this->config);
 
         $conf->set('group.id', $this->config->getConsumerGroupId());
         $conf->set('auto.offset.reset', $this->config->getConsumerOffsetReset());

--- a/src/Connectors/Consumer/LowLevel.php
+++ b/src/Connectors/Consumer/LowLevel.php
@@ -19,7 +19,7 @@ class LowLevel extends AbstractConnector implements ConnectorInterface
     {
         $broker = $this->config->getBrokerConfig();
 
-        $conf = $this->getConf($broker);
+        $conf = $this->getDefaultConf($broker);
 
         $conf->set('group.id', $this->config->getConsumerGroupId());
 

--- a/src/Connectors/Consumer/LowLevel.php
+++ b/src/Connectors/Consumer/LowLevel.php
@@ -1,8 +1,8 @@
 <?php
 namespace Metamorphosis\Connectors\Consumer;
 
-use Metamorphosis\Connectors\AbstractConnector;
 use Metamorphosis\Config\Consumer as ConfigConsumer;
+use Metamorphosis\Connectors\AbstractConnector;
 use Metamorphosis\Consumers\ConsumerInterface;
 use Metamorphosis\Consumers\LowLevel as LowLevelConsumer;
 use RdKafka\Consumer;

--- a/src/Connectors/Consumer/LowLevel.php
+++ b/src/Connectors/Consumer/LowLevel.php
@@ -1,32 +1,27 @@
 <?php
 namespace Metamorphosis\Connectors\Consumer;
 
-use Metamorphosis\Config\Consumer as ConsumerConfig;
+use Metamorphosis\Connectors\AbstractConnector;
+use Metamorphosis\Config\Consumer as ConfigConsumer;
 use Metamorphosis\Consumers\ConsumerInterface;
 use Metamorphosis\Consumers\LowLevel as LowLevelConsumer;
-use RdKafka\Conf;
 use RdKafka\Consumer;
 use RdKafka\TopicConf;
 
-class LowLevel implements ConnectorInterface
+class LowLevel extends AbstractConnector implements ConnectorInterface
 {
-    /**
-     * @var ConsumerConfig
-     */
-    protected $config;
-
-    public function __construct(ConsumerConfig $config)
+    public function __construct(ConfigConsumer $config)
     {
         $this->config = $config;
     }
 
     public function getConsumer(): ConsumerInterface
     {
-        $conf = $this->getConf();
-        $conf->set('group.id', $this->config->getConsumerGroupId());
-
         $broker = $this->config->getBrokerConfig();
-        $broker->authenticate($conf);
+
+        $conf = $this->getConf($broker);
+
+        $conf->set('group.id', $this->config->getConsumerGroupId());
 
         $consumer = new Consumer($conf);
         $consumer->addBrokers($broker->getConnections());
@@ -50,10 +45,5 @@ class LowLevel implements ConnectorInterface
         $topicConfig->set('auto.offset.reset', $this->config->getConsumerOffsetReset());
 
         return $topicConfig;
-    }
-
-    protected function getConf(): Conf
-    {
-        return resolve(Conf::class);
     }
 }

--- a/src/Connectors/Consumer/LowLevel.php
+++ b/src/Connectors/Consumer/LowLevel.php
@@ -17,14 +17,12 @@ class LowLevel extends AbstractConnector implements ConnectorInterface
 
     public function getConsumer(): ConsumerInterface
     {
-        $broker = $this->config->getBrokerConfig();
-
-        $conf = $this->getDefaultConf($broker);
+        $conf = $this->getDefaultConf($this->config);
 
         $conf->set('group.id', $this->config->getConsumerGroupId());
 
         $consumer = new Consumer($conf);
-        $consumer->addBrokers($broker->getConnections());
+        $consumer->addBrokers($this->config->getBrokerConfig()->getConnections());
 
         $topicConfig = $this->getTopicConfigs();
 

--- a/src/Connectors/Producer/Connector.php
+++ b/src/Connectors/Producer/Connector.php
@@ -1,7 +1,9 @@
 <?php
 namespace Metamorphosis\Connectors\Producer;
 
+use Metamorphosis\Config\AbstractConfig;
 use Metamorphosis\Config\Producer;
+use Metamorphosis\Connectors\AbstractConnector;
 use Metamorphosis\TopicHandler\Producer\HandleableResponseInterface;
 use Metamorphosis\TopicHandler\Producer\HandlerInterface;
 use RdKafka\Conf;
@@ -9,7 +11,7 @@ use RdKafka\Message;
 use RdKafka\Producer as KafkaProducer;
 use RdKafka\ProducerTopic;
 
-class Connector
+class Connector extends AbstractConnector
 {
     /**
      * @var Queue
@@ -35,13 +37,9 @@ class Connector
     {
         $broker = $config->getBrokerConfig();
 
-        $conf = resolve(Conf::class);
-
-        $conf->set('metadata.broker.list', $broker->getConnections());
+        $conf = $this->getConf($broker);
 
         $this->setCallbackResponses($conf);
-
-        $broker->authenticate($conf);
 
         $producer = app(KafkaProducer::class, compact('conf'));
 

--- a/src/Connectors/Producer/Connector.php
+++ b/src/Connectors/Producer/Connector.php
@@ -37,7 +37,7 @@ class Connector extends AbstractConnector
     {
         $broker = $config->getBrokerConfig();
 
-        $conf = $this->getConf($broker);
+        $conf = $this->getDefaultConf($broker);
 
         $this->setCallbackResponses($conf);
 

--- a/src/Connectors/Producer/Connector.php
+++ b/src/Connectors/Producer/Connector.php
@@ -35,9 +35,7 @@ class Connector extends AbstractConnector
 
     public function getProducerTopic(Producer $config): ProducerTopic
     {
-        $broker = $config->getBrokerConfig();
-
-        $conf = $this->getDefaultConf($broker);
+        $conf = $this->getDefaultConf($config);
 
         $this->setCallbackResponses($conf);
 

--- a/tests/Authentication/SSLAuthenticationTest.php
+++ b/tests/Authentication/SSLAuthenticationTest.php
@@ -19,7 +19,7 @@ class SSLAuthenticationTest extends LaravelTestCase
 
         $sslAuthentication = new SSLAuthentication($authConfig);
 
-        $this->assertNull($sslAuthentication->authenticate(new Conf()));
+        $this->assertNull($sslAuthentication->setAuthentication(new Conf()));
     }
 
     /** @test */
@@ -34,6 +34,6 @@ class SSLAuthenticationTest extends LaravelTestCase
 
         $this->expectException(AuthenticationException::class);
 
-        $sslAuthentication->authenticate(new Conf());
+        $sslAuthentication->setAuthentication(new Conf());
     }
 }

--- a/tests/BrokerTest.php
+++ b/tests/BrokerTest.php
@@ -17,10 +17,10 @@ class BrokerTest extends LaravelTestCase
     }
 
     /** @test */
-    public function it_should_authenticate()
+    public function it_should_prepare_authentication()
     {
         $broker = new Broker('some-connection');
 
-        $this->assertNull($broker->authenticate(new Conf()));
+        $this->assertNull($broker->prepareAuthentication(new Conf()));
     }
 }

--- a/tests/Config/AbstractConfigTest.php
+++ b/tests/Config/AbstractConfigTest.php
@@ -7,7 +7,7 @@ use Metamorphosis\Config\AbstractConfig;
 use Metamorphosis\Exceptions\ConfigurationException;
 use Tests\LaravelTestCase;
 
-class ConfigTest extends LaravelTestCase
+class AbstractConfigTest extends LaravelTestCase
 {
     public function setUp()
     {

--- a/tests/Config/AbstractConfigTest.php
+++ b/tests/Config/AbstractConfigTest.php
@@ -171,4 +171,42 @@ class AbstractConfigTest extends LaravelTestCase
 
         $this->assertEmpty($config->getMiddlewares());
     }
+
+    public function testItAcceptHighPerformanceConfigurationPerTopic()
+    {
+        config([
+            'kafka.topics' => [
+                'topic-high-performance-enabled-active' => [
+                    'topic' => 'topic-name',
+                    'broker' => 'default',
+                ],
+                'topic-high-performance-enable-passive' => [
+                    'topic' => 'topic-name',
+                    'broker' => 'default',
+                    'high-performance' => true,
+                ],
+                'topic-high-performance-inactive' => [
+                    'topic' => 'topic-name',
+                    'broker' => 'default',
+                    'high-performance' => false,
+                ],
+            ],
+        ]);
+
+        $topicKey = 'topic-high-performance-enabled-active';
+        $configEnabledActive = new class($topicKey) extends AbstractConfig {
+        };
+
+        $topicKey = 'topic-high-performance-enable-passive';
+        $configEnabledPassive = new class($topicKey) extends AbstractConfig {
+        };
+
+        $topicKey = 'topic-high-performance-inactive';
+        $configDisabled = new class($topicKey) extends AbstractConfig {
+        };
+
+        $this->assertTrue($configEnabledActive->enableHighPerformance());
+        $this->assertTrue($configEnabledPassive->enableHighPerformance());
+        $this->assertFalse($configDisabled->enableHighPerformance());
+    }
 }

--- a/tests/Config/AbstractConfigTest.php
+++ b/tests/Config/AbstractConfigTest.php
@@ -205,8 +205,8 @@ class AbstractConfigTest extends LaravelTestCase
         $configDisabled = new class($topicKey) extends AbstractConfig {
         };
 
-        $this->assertTrue($configEnabledActive->enableHighPerformance());
-        $this->assertTrue($configEnabledPassive->enableHighPerformance());
-        $this->assertFalse($configDisabled->enableHighPerformance());
+        $this->assertTrue($configEnabledActive->isHighPerformanceEnabled());
+        $this->assertTrue($configEnabledPassive->isHighPerformanceEnabled());
+        $this->assertFalse($configDisabled->isHighPerformanceEnabled());
     }
 }

--- a/tests/Config/ProducerTest.php
+++ b/tests/Config/ProducerTest.php
@@ -80,7 +80,7 @@ class ProducerTest extends LaravelTestCase
             'first_topic_middleware',
         ], $config->getMiddlewares());
 
-        $this->assertSame(50, $config->getTimeoutResponse());
+        $this->assertSame(1, $config->getTimeoutResponse());
     }
 
     /** @test */

--- a/tests/Connectors/Consumer/HighLevelTest.php
+++ b/tests/Connectors/Consumer/HighLevelTest.php
@@ -22,7 +22,7 @@ class HighLevelTest extends LaravelTestCase
             ->will($this->returnValue($this->createMock(Broker::class)));
 
         $config->expects($this->once())
-            ->method('enableHighPerformance')
+            ->method('isHighPerformanceEnabled')
             ->will($this->returnValue(true));
 
         $config->expects($this->once())

--- a/tests/Connectors/Consumer/HighLevelTest.php
+++ b/tests/Connectors/Consumer/HighLevelTest.php
@@ -22,6 +22,10 @@ class HighLevelTest extends LaravelTestCase
             ->will($this->returnValue($this->createMock(Broker::class)));
 
         $config->expects($this->once())
+            ->method('enableHighPerformance')
+            ->will($this->returnValue(true));
+
+        $config->expects($this->once())
             ->method('getConsumerGroupId')
             ->will($this->returnValue('group.id'));
 

--- a/tests/Connectors/Consumer/LowLevelTest.php
+++ b/tests/Connectors/Consumer/LowLevelTest.php
@@ -22,6 +22,10 @@ class LowLevelTest extends LaravelTestCase
             ->will($this->returnValue($this->createMock(Broker::class)));
 
         $config->expects($this->once())
+            ->method('enableHighPerformance')
+            ->will($this->returnValue(true));
+
+        $config->expects($this->once())
             ->method('getConsumerGroupId')
             ->will($this->returnValue('group.id'));
 

--- a/tests/Connectors/Consumer/LowLevelTest.php
+++ b/tests/Connectors/Consumer/LowLevelTest.php
@@ -22,7 +22,7 @@ class LowLevelTest extends LaravelTestCase
             ->will($this->returnValue($this->createMock(Broker::class)));
 
         $config->expects($this->once())
-            ->method('enableHighPerformance')
+            ->method('isHighPerformanceEnabled')
             ->will($this->returnValue(true));
 
         $config->expects($this->once())

--- a/tests/Connectors/Consumer/LowLevelTest.php
+++ b/tests/Connectors/Consumer/LowLevelTest.php
@@ -17,7 +17,7 @@ class LowLevelTest extends LaravelTestCase
 
         $connector = new LowLevel($config);
 
-        $config->expects($this->once())
+        $config->expects($this->exactly(2))
             ->method('getBrokerConfig')
             ->will($this->returnValue($this->createMock(Broker::class)));
 

--- a/tests/Connectors/Producer/ConnectorTest.php
+++ b/tests/Connectors/Producer/ConnectorTest.php
@@ -17,7 +17,7 @@ class ConnectorTest extends LaravelTestCase
         $config = $this->createMock(Producer::class);
 
         $config->expects($this->once())
-            ->method('enableHighPerformance')
+            ->method('isHighPerformanceEnabled')
             ->will($this->returnValue(true));
 
         $connector = new Connector();

--- a/tests/Connectors/Producer/ConnectorTest.php
+++ b/tests/Connectors/Producer/ConnectorTest.php
@@ -16,6 +16,10 @@ class ConnectorTest extends LaravelTestCase
     {
         $config = $this->createMock(Producer::class);
 
+        $config->expects($this->once())
+            ->method('enableHighPerformance')
+            ->will($this->returnValue(true));
+
         $connector = new Connector();
 
         $producer = $connector->getProducerTopic($config);


### PR DESCRIPTION
see > https://github.com/arnaud-lb/php-rdkafka#interesting-configuration-parameters


> Performance / Low-latency settings
Here is a configuration optimized for low latency. This allows a PHP process / request to send messages ASAP and to terminate quickly.
```php
<?php

$conf = new \RdKafka\Conf();
$conf->set('socket.timeout.ms', 50); // or socket.blocking.max.ms, depending on librdkafka version
if (function_exists('pcntl_sigprocmask')) {
    pcntl_sigprocmask(SIG_BLOCK, array(SIGIO));
    $conf->set('internal.termination.signal', SIGIO);
} else {
    $conf->set('queue.buffering.max.ms', 1);
}

$producer = new \RdKafka\Producer($conf);
$consumer = new \RdKafka\Consumer($conf);
```