### PR TITLE
fix(config): prevent error dispatch on undecladed constant

### DIFF
--- a/config/kafka.php
+++ b/config/kafka.php
@@ -139,7 +139,7 @@ return [
 
                 // Here you can configure which partition you want to send the message
                 // it can be -1 (RD_KAFKA_PARTITION_UA) to let Kafka decide, or an int with the partition number
-                'partition' => RD_KAFKA_PARTITION_UA,
+                'partition' => constant('RD_KAFKA_PARTITION_UA') ?? -1,
             ],
         ],
     ],


### PR DESCRIPTION
When constant _`RD_KAFKA_PARTITION_UA`_ is undeclared, jobs using Metamorphosis on your own default config, will throw a error:
![image](https://user-images.githubusercontent.com/13575101/122239791-9d566300-ce97-11eb-8c45-d9ba416cb754.png)

Fixed using a check for constant e a default value (as described on comment about config key) when absent.