### PR TITLE
FloatType - Handle with float on json

### DIFF
--- a/src/TopicHandler/Producer/AbstractHandler.php
+++ b/src/TopicHandler/Producer/AbstractHandler.php
@@ -71,7 +71,7 @@ abstract class AbstractHandler implements HandlerInterface
 
     private function encodeRecord(array $record): string
     {
-        $record = json_encode($record);
+        $record = json_encode($record, JSON_PRESERVE_ZERO_FRACTION);
 
         if (JSON_ERROR_NONE !== json_last_error()) {
             throw new JsonException('Cannot convert data into a valid JSON. Reason: '.json_last_error_msg());

--- a/tests/Unit/TopicHandler/Producer/AbstractHandlerTest.php
+++ b/tests/Unit/TopicHandler/Producer/AbstractHandlerTest.php
@@ -31,7 +31,7 @@ class AbstractHandlerTest extends LaravelTestCase
     public function testShouldCreateEncodeJsonWhenRecordIsArray(): void
     {
         // Set
-        $record = ['number' => 1];
+        $record = ['number' => 1, 'float' => 0.0];
         $topic = 'default';
         $key = 'default_1';
         $partition = 1;
@@ -45,7 +45,7 @@ class AbstractHandlerTest extends LaravelTestCase
         $this->assertInstanceOf(ProducerRecord::class, $result);
         $this->assertSame($key, $result->getKey());
         $this->assertSame($topic, $result->getTopicName());
-        $this->assertSame(json_encode($record), $result->getPayload());
+        $this->assertSame('{"number":1,"float":0.0}', $result->getPayload());
         $this->assertSame($partition, $result->getPartition());
     }
 }


### PR DESCRIPTION
When has a float number like 0.0 or 1.0 json_encode cast to int, we need to fix this to avoid avro invalid schema error