### PR TITLE
fix: Improve schema path flexibility

### DIFF
--- a/src/Avro/CachedSchemaRegistryClient.php
+++ b/src/Avro/CachedSchemaRegistryClient.php
@@ -71,7 +71,7 @@ class CachedSchemaRegistryClient
         $schema = app(Schema::class);
 
         $version = 'latest' === $version ? 'latest' : (int) $version;
-        $url = sprintf('/subjects/%s/versions/%s', $subject, $version);
+        $url = sprintf('subjects/%s/versions/%s', $subject, $version);
         [$status, $response] = $this->client->get($url);
 
         if (404 === $status) {

--- a/tests/Unit/Avro/CachedSchemaRegistryClientTest.php
+++ b/tests/Unit/Avro/CachedSchemaRegistryClientTest.php
@@ -144,7 +144,7 @@ class CachedSchemaRegistryClientTest extends LaravelTestCase
 
         // Expectations
         $httpClient->expects()
-            ->get('/subjects/some-kafka-topic/versions/1')
+            ->get('subjects/some-kafka-topic/versions/1')
             ->andReturn([$status, $response]);
 
         // Actions
@@ -173,7 +173,7 @@ class CachedSchemaRegistryClientTest extends LaravelTestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Schema not found');
         $httpClient->expects()
-            ->get('/subjects/some-kafka-topic/versions/1')
+            ->get('subjects/some-kafka-topic/versions/1')
             ->andReturn([$status, $response]);
 
         // Actions
@@ -199,7 +199,7 @@ class CachedSchemaRegistryClientTest extends LaravelTestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage("Unable to get schema for the specific ID: {$status}");
         $httpClient->expects()
-            ->get('/subjects/some-kafka-topic/versions/1')
+            ->get('subjects/some-kafka-topic/versions/1')
             ->andReturn([$status, $response]);
 
         // Actions
@@ -223,7 +223,7 @@ class CachedSchemaRegistryClientTest extends LaravelTestCase
 
         // Expectations
         $httpClient->expects()
-            ->get('/subjects/some-kafka-topic/versions/latest')
+            ->get('subjects/some-kafka-topic/versions/latest')
             ->once()
             ->andReturn([$status, $response]);
 


### PR DESCRIPTION
Problem: currently the schema URL which is built has a absolute path prefix `/` to retrieve the schema from the registry. Most of the schema registries like api curio by default have a url postfix like `https://registry-host/apis/ccompat/v6/` to get to their schema registry location. 

when we configure that as our registry base_uri, guzzle splits it up into the base uri and the path for the client. When our client makes a request to the registry with the absolute path prefix, it ends up going to `https://registry-host/schemas/ids/{id}` rather than `https://registry-host/apis/ccompat/v6/schemas/ids/{id}` and the cached registry client gets 404 and hangs without handling it

This PR removes the absolute path postfix so that the call can be made to the right base_uri and not just the right host.