### PR TITLE
Change configuration files format 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added file `config/service.php` to configure broker and authentication
-- Added AvroSchemaMixedEncoderTest
-- Added AvroSchemaDecoderTest
-- Added ProducerWithConfigOptionsTest
-- Added ConfigOptionsCommand to run commands with ConfigOptions class
-- Added pt_BR contributing section
-- Added setup-dev script on composer
-- Added grumphp commit validation 
+-  Added file `config/service.php` to configure broker and authentication
+-  Added AvroSchemaMixedEncoderTest
+-  Added AvroSchemaDecoderTest
+-  Added ProducerWithConfigOptionsTest
+-  Added ConfigOptionsCommand to run commands with ConfigOptions class
+-  Added pt_BR contributing section
+-  Added setup-dev script on composer
+-  Added grumphp commit validation 
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,36 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- 
-
-### Fixed
-
--
-
-### Changed
-
--
-
-### Removed
-- Remove deprecated class AbstractHandler
-
-## [4.1.0] - 2022-03-23
-
-### Added
+- Added file `config/service.php` to configure broker and authentication
 - Added AvroSchemaMixedEncoderTest
 - Added AvroSchemaDecoderTest
 - Added ProducerWithConfigOptionsTest
 - Added ConfigOptionsCommand to run commands with ConfigOptions class
 - Added pt_BR contributing section
 - Added setup-dev script on composer
-- Added grumphp commit validation
+- Added grumphp commit validation 
 
-### Fixed 
+### Fixed
+
 - Fixed parameters and options override on Consumer\Config class
 - Update instructions on contribute section
 - Update project install section
 
 ### Changed
+
 - Updated class from ConfigManager to ConfigOptions on unit tests
 - Updated class from ConfigManager to ConfigOptions where any config request was made
 - Consumer and Producer middlewares resolution
+
+### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ConfigOptionsCommand to run commands with ConfigOptions class
 - Added pt_BR contributing section
 - Added setup-dev script on composer
-- Added grumphp commit validation 
+- Added grumphp commit validation
 - Added file `config/service.php` to configure broker and authentication
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--  Added file `config/service.php` to configure broker and authentication
--  Added AvroSchemaMixedEncoderTest
--  Added AvroSchemaDecoderTest
--  Added ProducerWithConfigOptionsTest
--  Added ConfigOptionsCommand to run commands with ConfigOptions class
--  Added pt_BR contributing section
--  Added setup-dev script on composer
--  Added grumphp commit validation 
+- Added AvroSchemaMixedEncoderTest
+- Added AvroSchemaDecoderTest
+- Added ProducerWithConfigOptionsTest
+- Added ConfigOptionsCommand to run commands with ConfigOptions class
+- Added pt_BR contributing section
+- Added setup-dev script on composer
+- Added grumphp commit validation 
+- Added file `config/service.php` to configure broker and authentication
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added pt_BR contributing section
 - Added setup-dev script on composer
 - Added grumphp commit validation
-- Added file `config/service.php` to configure broker and authentication
 
 ### Fixed
 

--- a/config/kafka.php
+++ b/config/kafka.php
@@ -1,122 +1,46 @@
 <?php
 
 return [
-    /*
-    |--------------------------------------------------------------------------
-    | AVRO Schemas
-    |--------------------------------------------------------------------------
-    |
-    | Here you may specify the schema details configured on topic's broker key.
-    | Schema are kind of "contract" between the producer and consumer.
-    | For now, we are just decoding AVRO, not encoding.
-    |
-    */
-
-    'avro_schemas' => [
-        'default' => [
-            'url' => '',
-            // Disable SSL verification on schema request.
-            'ssl_verify' => true,
-            // This option will be put directly into a Guzzle http request
-            // Use this to do authorizations or send any headers you want.
-            // Here is a example of basic authentication on AVRO schema.
-            'request_options' => [
-                'headers' => [
-                    'Authorization' => [
-                        'Basic '.base64_encode(
-                            env('AVRO_SCHEMA_USERNAME').':'.env('AVRO_SCHEMA_PASSWORD')
-                        ),
-                    ],
-                ],
-            ],
-        ],
-    ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | Brokers
-    |--------------------------------------------------------------------------
-    |
-    | Here you may specify the connections details for each broker configured
-    | on topic's broker key.
-    |
-    */
-
-    'brokers' => [
-        'default' => [
-            'connections' => 'kafka:9092',
-
-            // If your broker doest not have authentication, you can
-            // remove this configuration, or set as empty.
-            // The Authentication types may be "ssl" or "none"
-            'auth' => [
-                'type' => 'ssl', // ssl and none
-                'ca' => storage_path('ca.pem'),
-                'certificate' => storage_path('kafka.cert'),
-                'key' => storage_path('kafka.key'),
-            ],
-        ],
-    ],
-
     'topics' => [
-        // This is your topic "keyword" where you will put all configurations needed
-        // on this specific topic.
         'default' => [
-            // The topic id is where you want to send or consume
-            // your messages from kafka.
             'topic_id' => 'kafka-test',
-
-            // Here you may point the key of the broker configured above.
-            'broker' => 'default',
-
-            // Configurations specific for consumer
             'consumer' => [
-                // You may define more than one consumer group per topic.
-                // If there is just one defined, it will be used by default,
-                // otherwise, you may pass which consumer group should be used
-                // when using the consumer command.
-                'consumer_groups' => [
-                    'test-consumer-group' => [
+                'consumer_group' => 'test-consumer-group',
+                // Action to take when there is no initial
+                // offset in offset store or the desired offset is out of range.
+                // This config will be passed to 'auto.offset.reset'.
+                // The valid options are: smallest, earliest, beginning, largest, latest, end, error.
+                'offset_reset' => 'earliest',
 
-                        // Action to take when there is no initial
-                        // offset in offset store or the desired offset is out of range.
-                        // This config will be passed to 'auto.offset.reset'.
-                        // The valid options are: smallest, earliest, beginning, largest, latest, end, error.
-                        'offset_reset' => 'earliest',
+                // The offset at which to start consumption. This only applies if partition is set.
+                // You can use a positive integer or any of the constants: RD_KAFKA_OFFSET_BEGINNING,
+                // RD_KAFKA_OFFSET_END, RD_KAFKA_OFFSET_STORED.
+                'offset' => 0,
 
-                        // The offset at which to start consumption. This only applies if partition is set.
-                        // You can use a positive integer or any of the constants: RD_KAFKA_OFFSET_BEGINNING,
-                        // RD_KAFKA_OFFSET_END, RD_KAFKA_OFFSET_STORED.
-                        'offset' => 0,
+                // The partition to consume. It can be null,
+                // if you don't wish do specify one.
+                'partition' => 0,
 
-                        // The partition to consume. It can be null,
-                        // if you don't wish do specify one.
-                        'partition' => 0,
+                // A consumer class that implements ConsumerTopicHandler
+                'handler' => '\App\Kafka\Consumers\ConsumerExample',
 
-                        // A consumer class that implements ConsumerTopicHandler
-                        'handler' => '\App\Kafka\Consumers\ConsumerExample',
+                // A Timeout to listen to a message. That means: how much
+                // time we need to wait until receiving a message?
+                'timeout' => 20000,
 
-                        // A Timeout to listen to a message. That means: how much
-                        // time we need to wait until receiving a message?
-                        'timeout' => 20000,
+                // Once you've enabled this, the Kafka consumer will commit the
+                // offset of the last message received in response to its poll() call
+                'auto_commit' => true,
 
-                        // Once you've enabled this, the Kafka consumer will commit the
-                        // offset of the last message received in response to its poll() call
-                        'auto_commit' => true,
+                // If commit_async is false process block until offsets are committed or the commit fails.
+                // Only works when auto_commit is false
+                'commit_async' => false,
 
-                        // If commit_async is false process block until offsets are committed or the commit fails.
-                        // Only works when auto_commit is false
-                        'commit_async' => false,
-
-                        // An array of middlewares applied only for this consumer_group
-                        'middlewares' => [],
-                    ],
-                ],
+                // An array of middlewares applied only for this consumer_group
+                'middlewares' => [],
             ],
 
-            // Configurations specific for producer
             'producer' => [
-
                 // Sets to true if you want to know if a message was successfully posted.
                 'required_acknowledgment' => true,
 
@@ -143,30 +67,6 @@ return [
                 // it can be -1 (RD_KAFKA_PARTITION_UA) to let Kafka decide, or an int with the partition number
                 'partition' => constant('RD_KAFKA_PARTITION_UA') ?? -1,
             ],
-        ],
-    ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | Global Middlewares
-    |--------------------------------------------------------------------------
-    |
-    | Here you may specify the global middlewares that will be applied for every
-    | consumed topic. Middlewares work between the received data from broker and
-    | before being passed into consumers.
-    | Available middlewares: log, avro-decode
-    |
-    */
-
-    'middlewares' => [
-        'consumer' => [
-            \Metamorphosis\Middlewares\Log::class,
-        ],
-        'producer' => [
-            \Metamorphosis\Middlewares\Log::class,
-        ],
-        'global' => [
-            \Metamorphosis\Middlewares\Log::class,
         ],
     ],
 ];

--- a/config/kafka.php
+++ b/config/kafka.php
@@ -2,8 +2,14 @@
 
 return [
     'topics' => [
+        // This is your topic "keyword" where you will put all configurations needed
+        // on this specific topic.
         'default' => [
+            // The topic id is where you want to send or consume
+            // your messages from kafka.
             'topic_id' => 'kafka-test',
+
+            //your consumer configurations
             'consumer' => [
                 'consumer_group' => 'test-consumer-group',
                 // Action to take when there is no initial

--- a/config/service.php
+++ b/config/service.php
@@ -1,0 +1,28 @@
+<?php
+
+return [
+    'avro_schema' => [
+        'url' => '',
+        'request_options' => [
+            'headers' => [
+                'Authorization' => [
+                    'Basic '.base64_encode(
+                        env('AVRO_SCHEMA_USERNAME').':'.env('AVRO_SCHEMA_PASSWORD')
+                    ),
+                ],
+            ],
+        ],
+        'ssl_verify' => true,
+        'username' => 'USERNAME',
+        'password' => 'PASSWORD',
+    ],
+    'broker' => [
+        'connections' => 'kafka:9092',
+        'auth' => [
+            'type' => 'ssl', // ssl and none
+            'ca' => storage_path('ca.pem'),
+            'certificate' => storage_path('kafka.cert'),
+            'key' => storage_path('kafka.key'),
+        ],
+    ],
+];

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -181,10 +181,17 @@ $ php artisan make:kafka-consumer PriceUpdateHandler
 This will create a KafkaConsumer class inside the application, on the `app/Kafka/Consumers/` directory.
 
 There, you'll have a `handler` method, which will send all records from the topic to the Consumer.
-Methods will be available for handling exceptions:
+
+Available methods:
+
  - `warning` method will be call whenever something not critical is received from the topic.
     Like a message informing that there's no more records to consume.
- - `failure` method will be call whenever something critical happens, like an error to decode the record.
+
+
+ - `failure` will be call whenever something critical happens, like an error to decode the record.
+
+
+ - `finished`  will be call when queue finishes
 
 ```php
 use App\Repository;
@@ -230,6 +237,11 @@ class PriceUpdateHandler extends AbstractHandler
     {
         // handle failure exception
     }
+    
+    public function finished(): void
+    {
+        //handle queue end
+    }    
 }
 ```
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -275,29 +275,42 @@ stdout_logfile=/var/log/default/kafka-consumer-price-update.log
 
 Although you can run this simple command, it provides some options you can pass to make it more flexible to your needs.
 
-- `--broker=`
-
-    Sometimes, you may want to change which broker the consumer should connect to (maybe for testing/debug purposes).
-    For that, you just nedd to call the `--broker` option with another broker connection key already set in the `config/kafka.php` file.
-
-    `$ php artisan kafka:consume price-update --broker='some-other-broker'`
 
 - `--offset=`
 
     And if you need to start the consumption of a topic in a specific offset (it can be useful for debug purposes)
     you can pass the `--offset=` option, but for this, it will be required to specify the partition too.
 
-    `$ php artisan kafka:consume price-update --partition=2 --offset=34`
+
+    $ php artisan kafka:consume price-update --partition=2 --offset=34
+
 
 - `--partition=`
 
-    If you wish do specify in which partition the consumer must be attached, you can set the option `--partition=`.
+    Set in which partition the consumer must be attached.
 
-    `$ php artisan kafka:consume price-update --partition=2 --offset=34`
+
+    $ php artisan kafka:consume price-update --partition=2 --offset=34
+
 
 - `--timeout=`
 
-   You can specify what would be the timeout for the consumer, by using the `--timeout=` option, the time is in milliseconds.
+   Set the timeout for the consumer in milliseconds.
 
-   `$ php artisan kafka:consume price-update --timeout=23000`
 
+   $ php artisan kafka:consume price-update --timeout=23000
+
+
+- `--config_name=`
+
+   Specify from what file topics configuration should be read.
+
+
+    $ php artisan kafka:consume topic-name --config_name=config.file
+
+
+- `--service_name=`
+
+    Specify from what file services configurations should be read.
+
+    `$ php artisan kafka:consume price-update --service_name=config.file`

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -136,8 +136,7 @@ If you wish, you may set a middleware to run of a topic level or a consumer grou
 ],
 ```
 
-The order matters here, they'll be execute as queue, from the most global scope to the most specific (global scope > topic scope > group_consumers scope).
-
+The order matters here, they'll execute as queue, from the most global scope to the most specific (global scope > topic scope > group_consumers scope).
 
 <a name="schemas"></a>
 ### Schemas
@@ -245,7 +244,6 @@ class PriceUpdateHandler extends AbstractHandler
 }
 ```
 
-
 <a name="commands-middleware"></a>
 #### Creating Middleware
 You can create a middleware class, that works between the received data from broker and before being passed into consumers, using the follow command:
@@ -287,7 +285,6 @@ stdout_logfile=/var/log/default/kafka-consumer-price-update.log
 
 Although you can run this simple command, it provides some options you can pass to make it more flexible to your needs.
 
-
 - `--offset=`
 
     And if you need to start the consumption of a topic in a specific offset (it can be useful for debug purposes)
@@ -323,6 +320,7 @@ Although you can run this simple command, it provides some options you can pass 
 
 - `--service_name=`
 
-    Specify from what file services configurations should be read.
+    Specify from what file services configurations should be read. 
 
-    `$ php artisan kafka:consume price-update --service_name=config.file`
+
+    $ php artisan kafka:consume price-update --service_name=config.file

--- a/docs/quick-usage.md
+++ b/docs/quick-usage.md
@@ -162,7 +162,8 @@ redirect_stderr=true
 stdout_logfile=/var/log/default/kafka-consumer-price-update.log
 ```
 
-### Using data objects
+<a name="config-dto"></a>
+#### Using data objects
 
 To configure and consume using classes:
 

--- a/docs/quick-usage.md
+++ b/docs/quick-usage.md
@@ -19,7 +19,6 @@ configuration and a file to keep the broker and schema configuration. In this ex
 This file keeps configurations about topics, consumers and producers.
 It should return an array of topics containing the topic name, topic_id,  consumer, producer and the settings for each one of them:
 
-
 ```php
 <?php
 
@@ -56,7 +55,6 @@ return [
 ### File `config/service.php`
 
 This file keeps configurations about **broker** and **schema** utilized.
-
 
 ```php
 <?php

--- a/docs/quick-usage.md
+++ b/docs/quick-usage.md
@@ -180,9 +180,6 @@ To configure and consume using classes:
     $consumer->consume();
 ```
 
-
-
-
 That's it. For more information about usage, middlewares, broker authentication, consumer groups and other advanced topics, please have a look at our [Advanced Usage Guide](advanced.md).
 
 <a name="produce-message"></a>

--- a/docs/quick-usage.md
+++ b/docs/quick-usage.md
@@ -8,76 +8,104 @@
   - [Produce Message](#produce-message)
 
 <a name="config"></a>
-### Config file: `config/kafka.php`
+### Configure using  files
 
-The config file holds all information about brokers, topics, consumer groups and middlewares.
+To get started using configuration files, at least two files are needed. A file to keep the topics
+configuration and a file to keep the broker and schema configuration. In this example, we will use the files  `config/kafka.php` and `config/service.php`.
 
-To quickly start using, we can focus in two sections:
-- Brokers
+### File `config/kafka.php`:
 
-    An array of brokers, with connection and authentication configurations:
+This file keeps configurations about topics, consumers and producers.
+It should return an array of topics containing the topic name, topic_id,  consumer, producer and the settings for each one of them:
 
-    - `connections`: *required*. can be a `string` with multiple connections separated by comma or an `array` of connections (as `string`)
 
-    - `auth`: *optional*. out of the box, the package can connect with SSL Authentication only or without any authentication
+```php
+<?php
 
-    ```php
-      'brokers' => [
-          'price_brokers' => [
-              'connections' => 'localhost:8091,localhost:8092',
-              'auth' => [
-                  'type' => 'ssl',
-                  'ca' => storage_path('ca.pem'),
-                  'certificate' => storage_path('kafka.cert'),
-                  'key' => storage_path('kafka.key'),
-              ],
-          ],
-          'stock_brokers' => [
-              'connections' => ['localhost:8091', 'localhost:8092'],
-              'auth' => [], // can be an empty array or even don't have this key in the broker config
-          ],
-      ],
-    ```
+return [
+    'topics' => [
+        'this_is_your_topic_name' => [
+            'topic_id' => "this_is_your_topic_id",
+            'consumer' => [
+                'consumer_group' => 'your-consumer-group',
+                'offset_reset' => 'earliest',
+                'offset' => 0,
+                'partition' => 0,
+                'handler' => '\App\Kafka\Consumers\ConsumerExample',
+                'timeout' => 20000,
+                'auto_commit' => true,
+                'commit_async' => false,
+                'middlewares' => [],
+            ],
+  
+            'producer' => [
+                'required_acknowledgment' => true,
+                'is_async' => true,
+                'max_poll_records' => 500,
+                'flush_attempts' => 10,
+                'middlewares' => [],
+                'timeout' => 10000,
+                'partition' => constant('RD_KAFKA_PARTITION_UA') ?? -1,
+            ],
+        ]
+    ],
+];
+```
 
-- Topics
+### File `config/service.php`
 
-    An array of topics configuration, such as the topic name, which broker connection should use, consumer groups and middlewares.
+This file keeps configurations about **broker** and **schema** utilized.
 
-    Here we can specify the group consumers, each topic can have multiple groups,
-    and each group holds the configuration for which consumer, offset_reset (for setting initial offset) and middleware it must use.
 
-    ```php
-      'topics' => [
-          'price_update' => [
-              'topic' => 'products.price.update',
-              'broker' => 'price_brokers',
-              'consumer_groups' => [
-                  'default' => [
-                      'offset_reset' => 'smallest',
-                      'handler' => '\App\Kafka\Consumers\PriceUpdateConsumer',
-                  ],
-              ],
-          ],
-      ],
-    ```
+```php
+<?php
+
+return [
+    'avro_schema' => [
+        'url' => '',
+        'request_options' => [
+            'headers' => [
+                'Authorization' => [
+                    'Basic ' . base64_encode(
+                        env('AVRO_SCHEMA_USERNAME').':'.env('AVRO_SCHEMA_PASSWORD')
+                    ),
+                ],
+            ],
+        ],
+
+        'ssl_verify' => true,
+        'username' => 'USERNAME',
+        'password' => 'PASSWORD',
+    ],
+    
+    'broker' => [
+        'connections' => 'kafka:9092',
+        'auth' => [
+            'type' => 'ssl', 
+            'ca' => storage_path('ca.pem'),
+            'certificate' => storage_path('kafka.cert'),
+            'key' => storage_path('kafka.key'),
+        ],
+    ],
+];
+```
+
 
 <a name="consumer"></a>
 ### Consumer
 
-After setting up the required configs, you need to create the consumer, which will handle all records received
-from the topic specified in the config.
+After setting up the required configuration, you must create a consumer to handle records received
+from the specified topic in your configuration.
 
 <a name="creating-consumer"></a>
-#### Creating Consumer
+#### Creating a Consumer
 
-Creating the consumer is easy as running the following command:
+To create a consumer run the following command:
 ```bash
 $ php artisan make:kafka-consumer PriceUpdateConsumer
 ```
-This will create a KafkaConsumer class inside the application, on the app/Kafka/Consumers/ directory
-
-There, you'll have a handler method, which will send all records from the topic to the Consumer,
-also, methods will be available for handling exceptions
+This will create a KafkaConsumer class on the app/Kafka/Consumers/ directory with the following
+content:
 
 ```php
 use App\Kafka\Consumers\PriceUpdateConsumer;
@@ -109,20 +137,19 @@ class PriceUpdateConsumer extends AbstractHandler
 ```
 
 <a name="running-consumer"></a>
-#### Running consumer
+#### Running the consumer
 
-Now you just need to start consuming the topic.
+To start consuming the topic, the simplest way to see it working is by running the kafka:consume command along with the topic name, topic configuration file and service configuration file:
 
-The simplest way to see it working is by running the kafka:consume command along with the topic name
-declared in the topics config key:
 
 ```bash
-$ php artisan kafka:consume price-update
+$ php artisan kafka:consume this_is_your_topic_name --config_name=config.file --service_name=service.file
 ```
 
 This command will run in a `while true`, that means, it will never stop running.
 But, errors can happen, so we strongly advice you to run this command along with [supervisor](http://supervisord.org/running.html),
 like this example below:
+
 ```bash
 [program:kafka-consumer-price-update]
 process_name=%(program_name)s_%(process_num)02d
@@ -137,30 +164,10 @@ stdout_logfile=/var/log/default/kafka-consumer-price-update.log
 
 That's it. For more information about usage, middlewares, broker authentication, consumer groups and other advanced topics, please have a look at our [Advanced Usage Guide](advanced.md).
 
-<a name="producer"></a>
-### Producer
-
-Producer also required configs, which will produce all records using parameters specified in the config.
-
-```php
-    'brokers' => [
-        'local-dev' => [
-            'connections' => 'kafka:9092',
-        ],
-    ],
-    'topics' => [
-        'product-updated' => [
-            'topic_id' => 'product_updated',
-            'broker' => 'local-dev',
-        ],
-    ],
-```
 <a name="produce-message"></a>
 ### Produce Message
 
-Creating Producer handler.
-
-The Producer must extends AbstractHandler class and can be empty.
+To create a producer handler, create a class that extends `Metamorphosis\TopicHandler\Producer\AbstractHandler` class:
 
 ```php
 <?php

--- a/docs/quick-usage.md
+++ b/docs/quick-usage.md
@@ -1,6 +1,7 @@
 ## Quick Usage Guide
 
-- [Config file](#config)
+- [Configure with files](#config)
+- [Configure using data objects](#config-dto)
 - [Consumer](#consumer)
    - [Creating Consumer](#creating-consumer)
    - [Running](#running-consumer)
@@ -90,7 +91,6 @@ return [
 ];
 ```
 
-
 <a name="consumer"></a>
 ### Consumer
 
@@ -144,7 +144,7 @@ To start consuming the topic, the simplest way to see it working is by running t
 
 ```bash
 $ php artisan kafka:consume this_is_your_topic_name --config_name=config.file --service_name=service.file
-```
+``` 
 
 This command will run in a `while true`, that means, it will never stop running.
 But, errors can happen, so we strongly advice you to run this command along with [supervisor](http://supervisord.org/running.html),
@@ -161,6 +161,27 @@ numprocs=6
 redirect_stderr=true
 stdout_logfile=/var/log/default/kafka-consumer-price-update.log
 ```
+
+### Using data objects
+
+To configure and consume using classes:
+
+```php
+    use Metamorphosis\Consumer;
+    use Metamorphosis\TopicHandler\ConfigOptions\Factories\ConsumerFactory;
+    
+    $topic = config('yourConfig.topics.topic-id');
+    $broker = config('yourService.broker');
+    $avro = config('yourService.avro_schema');
+    
+    $consumerConfiguration = ConsumerFactory::make($broker, $topic, $avro);
+    $consumer = app(Consumer::class, ['configOptions' => $consumerConfiguration]);
+    
+    $consumer->consume();
+```
+
+
+
 
 That's it. For more information about usage, middlewares, broker authentication, consumer groups and other advanced topics, please have a look at our [Advanced Usage Guide](advanced.md).
 

--- a/docs/quick-usage.md
+++ b/docs/quick-usage.md
@@ -12,7 +12,8 @@
 ### Configure using  files
 
 To get started using configuration files, at least two files are needed. A file to keep the topics
-configuration and a file to keep the broker and schema configuration. In this example, we will use the files  `config/kafka.php` and `config/service.php`.
+configuration and a file to keep the broker and schema configuration. In this example, we will use the files 
+`config/kafka.php` and `config/service.php`.
 
 ### File `config/kafka.php`:
 

--- a/src/Connectors/AbstractConfig.php
+++ b/src/Connectors/AbstractConfig.php
@@ -6,13 +6,17 @@ use Metamorphosis\Exceptions\ConfigurationException;
 
 abstract class AbstractConfig
 {
-    protected function getBrokerConfig(string $configName, string $brokerId): array
+    protected function getBrokerConfig(string $servicesFile): array
     {
-        if (!$brokerConfig = config($configName.".brokers.{$brokerId}")) {
-            throw new ConfigurationException("Broker '{$brokerId}' configuration not found");
+        if (!$brokerConfig = config($servicesFile.'.broker')) {
+            throw new ConfigurationException("Broker configuration not found on '{$servicesFile}'");
         }
-
         return $brokerConfig;
+    }
+
+    protected function getSchemaConfig(string $servicesFile): array
+    {
+        return config($servicesFile.'.avro_schema', []);
     }
 
     protected function validate(array $config): void
@@ -22,10 +26,5 @@ abstract class AbstractConfig
         if (!$validator->errors()->isEmpty()) {
             throw new ConfigurationException($validator->errors()->toJson());
         }
-    }
-
-    protected function getSchemaConfig(string $configName, string $topicId): array
-    {
-        return config($configName.'.avro_schemas.'.$topicId, []);
     }
 }

--- a/src/Connectors/Consumer/Config.php
+++ b/src/Connectors/Consumer/Config.php
@@ -53,7 +53,7 @@ class Config extends AbstractConfig
     public function make(array $options, array $arguments): Consumer
     {
         $configName = $options['config_name'] ?? 'kafka';
-        $service = $options['service'] ?? 'service';
+        $service = $options['service_name'] ?? 'service';
 
         $topicConfig = $this->getTopicConfig($configName, $arguments['topic']);
         $brokerConfig = $this->getBrokerConfig($service);

--- a/src/Connectors/Consumer/Config.php
+++ b/src/Connectors/Consumer/Config.php
@@ -85,18 +85,4 @@ class Config extends AbstractConfig
 
         return $topicConfig;
     }
-
-    /**
-     * Sometimes that user may pass `--partition=0` as argument.
-     * So if we just use array_filter here, this option will
-     * be removed.
-     *
-     * This code makes sure that only null values will be removed.
-     */
-    private function filterValues(array $options = []): array
-    {
-        return array_filter($options, function ($value) {
-            return !is_null($value);
-        });
-    }
 }

--- a/src/Connectors/Producer/Config.php
+++ b/src/Connectors/Producer/Config.php
@@ -49,12 +49,9 @@ class Config extends AbstractConfig
     public function makeByTopic(string $topicId): AbstractConfigManager
     {
         $topicConfig = $this->getTopicConfig($topicId);
-        $topicConfig['middlewares'] = array_merge(
-            config('kafka.middlewares.producer', []),
-            $topicConfig['producer']['middlewares'] ?? []
-        );
-        $brokerConfig = $this->getBrokerConfig('kafka', $topicConfig['broker']);
-        $schemaConfig = $this->getSchemaConfig('kafka', $topicId);
+        $topicConfig['middlewares'] = $topicConfig['producer']['middlewares'] ?? [];
+        $brokerConfig = $this->getBrokerConfig('service');
+        $schemaConfig = $this->getSchemaConfig('service');
         $config = array_merge($topicConfig, $brokerConfig, $schemaConfig);
 
         $this->validate($config);

--- a/src/Console/ConsumerCommand.php
+++ b/src/Console/ConsumerCommand.php
@@ -30,7 +30,8 @@ class ConsumerCommand extends BaseCommand
         {--broker= : Override broker connection from config.}
         {--timeout= : Sets timeout for consumer.}
         {--times= : Amount of messages to be consumed.}
-        {--config_name= : Change default name for laravel config file.}';
+        {--config_name= : Change default name for laravel config file.}
+        {--service_name= : Change default name for services config file.}';
 
     public function handle(Config $config)
     {

--- a/src/MetamorphosisServiceProvider.php
+++ b/src/MetamorphosisServiceProvider.php
@@ -14,9 +14,11 @@ class MetamorphosisServiceProvider extends ServiceProvider
     {
         $this->publishes([
             __DIR__.'/../config/kafka.php' => config_path('kafka.php'),
+            __DIR__.'/../config/service.php' => config_path('service.php'),
         ], 'config');
 
         $this->mergeConfigFrom(__DIR__.'/../config/kafka.php', 'kafka');
+        $this->mergeConfigFrom(__DIR__.'/../config/service.php', 'service');
     }
 
     public function register()

--- a/src/TopicHandler/ConfigOptions/Factories/ConsumerFactory.php
+++ b/src/TopicHandler/ConfigOptions/Factories/ConsumerFactory.php
@@ -21,10 +21,8 @@ class ConsumerFactory
     private static function getConsumerGroupConfig(array $topicData): array
     {
         $topicData['topicId'] = $topicData['topic_id'];
-        $topicData['consumerGroup'] = $topicData['consumer_group'];
-
-        $consumerGroup = $topicData['consumerGroup'];
-        $consumer = current($topicData['consumer'])[$consumerGroup];
+        $consumer = $topicData['consumer'];
+        $topicData['consumerGroup'] = $consumer['consumer_group'];
 
         return array_merge_recursive($topicData, self::convertConfigAttributes($consumer));
     }

--- a/tests/Integration/ProducerTest.php
+++ b/tests/Integration/ProducerTest.php
@@ -73,17 +73,17 @@ class ProducerTest extends LaravelTestCase
 
     protected function withoutAuthentication(): void
     {
-        config(['kafka.brokers.default.auth' => []]);
+        config(['service.broker.auth' => []]);
     }
 
     protected function haveAConsumerHandlerConfigured(): void
     {
-        config(['kafka.topics.default.consumer.consumer_groups.test-consumer-group.handler' => MessageConsumer::class]);
+        config(['kafka.topics.default.consumer.handler' => MessageConsumer::class]);
     }
 
     protected function haveAConsumerPartitionConfigured(): void
     {
-        config(['kafka.topics.default.consumer.consumer_groups.test-consumer-group.partition' => -1]);
+        config(['kafka.topics.default.consumer.partition' => -1]);
     }
 
     protected function runTheConsumer(): void
@@ -110,15 +110,12 @@ class ProducerTest extends LaravelTestCase
                         'topic_id' => 'low_level',
                         'broker' => 'default',
                         'consumer' => [
-                            'consumer_groups' => [
-                                'test-consumer-group' => [
-                                    'offset_reset' => 'earliest',
-                                    'offset' => 0,
-                                    'handler' => MessageConsumer::class,
-                                    'timeout' => 20000,
-                                    'middlewares' => [],
-                                ],
-                            ],
+                            'consumer_group' => 'test-consumer-group',
+                            'offset_reset' => 'earliest',
+                            'offset' => 0,
+                            'handler' => MessageConsumer::class,
+                            'timeout' => 20000,
+                            'middlewares' => [],
                         ],
                         'producer' => [
                             'required_acknowledgment' => true,

--- a/tests/Unit/Connectors/Consumer/ConfigTest.php
+++ b/tests/Unit/Connectors/Consumer/ConfigTest.php
@@ -7,6 +7,7 @@ use Metamorphosis\TopicHandler\ConfigOptions\Consumer as ConsumerConfigOptions;
 use Mockery as m;
 use Tests\LaravelTestCase;
 use Tests\Unit\Dummies\ConsumerHandlerDummy;
+use TypeError;
 
 class ConfigTest extends LaravelTestCase
 {
@@ -98,8 +99,10 @@ class ConfigTest extends LaravelTestCase
             'consumer_group' => 'default',
         ];
 
+        // Expectations
+        $this->expectException(TypeError::class);
+
         // Actions
-        $this->expectException(ConfigurationException::class);
         $configManager = $config->make($options, $arguments);
 
         // Assertions
@@ -109,7 +112,7 @@ class ConfigTest extends LaravelTestCase
     public function testShouldNotSetRuntimeConfigWhenKafkaConfigIsInvalid(): void
     {
         // Set
-        config(['kafka.brokers.default.connections' => null]);
+        config(['service.broker' => null]);
         $config = new Config();
         $options = [
             'partition' => 0,

--- a/tests/Unit/Connectors/Consumer/FactoryTest.php
+++ b/tests/Unit/Connectors/Consumer/FactoryTest.php
@@ -10,44 +10,11 @@ use Tests\Unit\Dummies\ConsumerHandlerDummy;
 
 class FactoryTest extends LaravelTestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        config([
-            'kafka' => [
-                'brokers' => [
-                    'default' => [
-                        'connections' => 'kafka:123',
-                    ],
-                ],
-                'topics' => [
-                    'topic_key' => [
-                        'topic_id' => 'topic_name',
-                        'broker' => 'default',
-                        'consumer' => [
-                            'consumer_groups' => [
-                                'with-partition' => [
-                                    'offset_reset' => 'earliest',
-                                    'offset' => 0,
-                                    'partition' => 0,
-                                    'handler' => ConsumerHandlerDummy::class,
-                                ],
-                                'without-partition' => [
-                                    'offset_reset' => 'earliest',
-                                    'handler' => ConsumerHandlerDummy::class,
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ]);
-    }
-
     public function testItMakesManagerWithLowLevelConsumer(): void
     {
         // Set
+        $this->haveAConsumerWithPartitionConfigured();
+
         $config = new Config();
         $configConsumer = $config->make(['timeout' => 61], ['topic' => 'topic_key', 'consumer_group' => 'with-partition']);
         $manager = Factory::make($configConsumer);
@@ -59,6 +26,7 @@ class FactoryTest extends LaravelTestCase
     public function testItMakesManagerWithHighLevelConsumerWhenPartitionIsNotValid(): void
     {
         // Set
+        $this->haveAConsumerWithoutPartitionConfigured();
         $config = new Config();
         $configConsumer = $config->make(['timeout' => 61, 'partition' => -1], ['topic' => 'topic_key', 'consumer_group' => 'with-partition']);
         $manager = Factory::make($configConsumer);
@@ -70,11 +38,60 @@ class FactoryTest extends LaravelTestCase
     public function testItMakesHighLevelClass(): void
     {
         // Set
+        $this->haveAConsumerWithoutPartitionConfigured();
         $config = new Config();
         $configConsumer = $config->make(['timeout' => 61], ['topic' => 'topic_key', 'consumer_group' => 'without-partition']);
         $manager = Factory::make($configConsumer);
 
         // Assertions
         $this->assertInstanceOf(HighLevel::class, $manager->getConsumer());
+    }
+
+    private function haveAConsumerWithPartitionConfigured()
+    {
+        config([
+            'kafka' => [
+                'topics' => [
+                    'topic_key' => [
+                        'topic_id' => 'topic_name',
+                        'consumer' => [
+                            'consumer_group' => 'with-partition',
+                            'offset_reset' => 'earliest',
+                            'offset' => 0,
+                            'partition' => 0,
+                            'handler' => ConsumerHandlerDummy::class,
+                        ],
+                    ],
+                ],
+            ],
+            'service' => [
+                'broker' => [
+                    'connections' => 'kafka:123',
+                ],
+            ],
+        ]);
+    }
+
+    private function haveAConsumerWithoutPartitionConfigured()
+    {
+        config([
+            'kafka' => [
+                'topics' => [
+                    'topic_key' => [
+                        'topic_id' => 'topic_name',
+                        'consumer' => [
+                            'consumer_group' => 'without-partition',
+                            'offset_reset' => 'earliest',
+                            'handler' => ConsumerHandlerDummy::class,
+                        ],
+                    ],
+                ],
+            ],
+            'service' => [
+                'broker' => [
+                    'connections' => 'kafka:123',
+                ],
+            ],
+        ]);
     }
 }

--- a/tests/Unit/Connectors/Producer/ConfigTest.php
+++ b/tests/Unit/Connectors/Producer/ConfigTest.php
@@ -23,7 +23,6 @@ class ConfigTest extends LaravelTestCase
             'max_poll_records' => 500,
             'flush_attempts' => 10,
             'partition' => -1,
-            'broker' => 'default',
             'topic' => 'default',
             'connections' => 'kafka:9092',
             'auth' => [
@@ -69,7 +68,6 @@ class ConfigTest extends LaravelTestCase
             'required_acknowledgment' => true,
             'max_poll_records' => 3000,
             'flush_attempts' => 10,
-            'broker' => 'default',
             'topic' => 'default',
             'connections' => 'kafka:9092',
             'auth' => [

--- a/tests/Unit/Console/ConsumerCommandTest.php
+++ b/tests/Unit/Console/ConsumerCommandTest.php
@@ -15,26 +15,22 @@ class ConsumerCommandTest extends LaravelTestCase
 
         config([
             'kafka' => [
-                'brokers' => [
-                    'default' => [
-                        'connections' => 'test_kafka:6680',
-                        'auth' => [],
-                    ],
-                ],
                 'topics' => [
                     'topic_key' => [
                         'topic_id' => 'topic_name',
-                        'broker' => 'default',
                         'consumer' => [
-                            'consumer_groups' => [
-                                'default' => [
-                                    'offset_reset' => 'earliest',
-                                    'handler' => ConsumerHandlerDummy::class,
-                                    'timeout' => 123,
-                                ],
-                            ],
+                            'consumer_group' => 'default',
+                            'offset_reset' => 'earliest',
+                            'handler' => ConsumerHandlerDummy::class,
+                            'timeout' => 123,
                         ],
                     ],
+                ],
+            ],
+            'service' => [
+                'broker' => [
+                    'connections' => 'test_kafka:6680',
+                    'auth' => [],
                 ],
             ],
         ]);

--- a/tests/Unit/TopicHandler/ConfigOptions/Factories/ConsumerFactoryTest.php
+++ b/tests/Unit/TopicHandler/ConfigOptions/Factories/ConsumerFactoryTest.php
@@ -32,20 +32,16 @@ class ConsumerFactoryTest extends LaravelTestCase
         ];
         $topicData = [
             'topic_id' => 'kafka-test',
-            'consumer_group' => 'test-consumer-group',
             'consumer' => [
-                'consumer_groups' => [
-                    'test-consumer-group' => [
-                        'middlewares' => [],
-                        'auto_commit' => true,
-                        'commit_async' => true,
-                        'offset_reset' => 'earliest',
-                        'handler' => '\App\Kafka\Consumers\ConsumerExample',
-                        'partition' => 0,
-                        'offset' => 0,
-                        'timeout' => 20000,
-                    ],
-                ],
+                'consumer_group' => 'test-consumer-group',
+                'middlewares' => [],
+                'auto_commit' => true,
+                'commit_async' => true,
+                'offset_reset' => 'earliest',
+                'handler' => '\App\Kafka\Consumers\ConsumerExample',
+                'partition' => 0,
+                'offset' => 0,
+                'timeout' => 20000,
             ],
         ];
         $expected = [


### PR DESCRIPTION
O formato do arquivo de configuração foi alterado para operar com as classes de dados.

Atualmente a configuração via arquivo permite que sejam configurados vários "consumers_groups" em um array.

No entanto, a classe de dados ConfigOptions\Consumer possui somente um consumer_group como atributo e isso conflita com o formato atual da configuração via arquivo. Para resolver o conflito, os arquivos de configuração  foram alterados para permitir apenas um consumer_group.

Antes: 

```php 
   'consumer' => [
                'consumer_groups' => [
                    'consumer-group' => [
                        'offset_reset' => 'earliest',
                        '...' => '...',
                    ],
                    'another-consumer-group' => [
                        'offset_reset' => 'earliest',  
                        '...' => '...',
                    ],
                ],
            ],`
```

Depois:

```php
    'consumer' => [
                'consumer_group' => 'consumer_group_name',
                'offset_reset' => 'earliest',  
                '...' => '...',
                ]
             ],
```

O processo de carregamento das configurações foi ajustado para fazer a leitura do novo formato, assim como os testes unitários.