### PR TITLE
Fix constant access in partition configuration

### DIFF
--- a/config/kafka.php
+++ b/config/kafka.php
@@ -143,7 +143,9 @@ return [
 
                 // Here you can configure which partition you want to send the message
                 // it can be -1 (RD_KAFKA_PARTITION_UA) to let Kafka decide, or an int with the partition number
-                'partition' => constant('RD_KAFKA_PARTITION_UA') ?? -1,
+                'partition' => defined('RD_KAFKA_PARTITION_UA')
+                    ? constant('RD_KAFKA_PARTITION_UA')
+                    : -1,
             ],
         ],
     ],


### PR DESCRIPTION
When accessing a constant that is not defined, a Warning or Error(PHP 8) will be generated. 

![Selection_126](https://user-images.githubusercontent.com/4405802/209186779-3491b152-b4e0-4bae-8316-87f838f12fdb.png)

This PR verifies the existence of the constant before accessing it, avoiding any errors.
