### PR TITLE
feat: improve config to accept max poll interval ms

### DIFF
--- a/config/kafka.php
+++ b/config/kafka.php
@@ -102,6 +102,10 @@ return [
                         // time we need to wait until receiving a message?
                         'timeout' => 20000,
 
+                        // A max interval for consumer to make poll calls. That means: how much
+                        // time we need to wait for poll calls until consider the consumer has inactive.
+                        'max_poll_interval_ms' => 300000,
+
                         // Once you've enabled this, the Kafka consumer will commit the
                         // offset of the last message received in response to its poll() call
                         'auto_commit' => true,

--- a/src/Connectors/Consumer/HighLevel.php
+++ b/src/Connectors/Consumer/HighLevel.php
@@ -14,9 +14,15 @@ class HighLevel implements ConnectorInterface
     public function getConsumer(bool $autoCommit, AbstractConfigManager $configManager): ConsumerInterface
     {
         $conf = $this->getConf($configManager);
+        $maxPollIntervalMs = (int) $configManager->get('max_poll_interval_ms');
 
         $conf->set('group.id', $configManager->get('consumer_group'));
         $conf->set('auto.offset.reset', $configManager->get('offset_reset'));
+        $conf->set(
+            'max.poll.interval.ms',
+            $maxPollIntervalMs ?: 300000
+        );
+
         if (!$autoCommit) {
             $conf->set('enable.auto.commit', 'false');
         }

--- a/src/Connectors/Consumer/LowLevel.php
+++ b/src/Connectors/Consumer/LowLevel.php
@@ -15,7 +15,14 @@ class LowLevel implements ConnectorInterface
     public function getConsumer(bool $autoCommit, AbstractConfigManager $configManager): ConsumerInterface
     {
         $conf = $this->getConf();
+        $maxPollIntervalMs = (int) $configManager->get('max_poll_interval_ms');
+
         $conf->set('group.id', $configManager->get('consumer_group'));
+        $conf->set(
+            'max.poll.interval.ms',
+            $maxPollIntervalMs ?: 300000
+        );
+
         if (!$autoCommit) {
             $conf->set('enable.auto.commit', 'false');
         }

--- a/tests/Unit/Connectors/Consumer/HighLevelTest.php
+++ b/tests/Unit/Connectors/Consumer/HighLevelTest.php
@@ -20,6 +20,7 @@ class HighLevelTest extends LaravelTestCase
             'topic_id' => 'some_topic',
             'offset_reset' => 'earliest',
             'timeout' => 1000,
+            'max_poll_interval_ms' => 900000,
         ]);
         $connector = new HighLevel();
 

--- a/tests/Unit/Connectors/Consumer/LowLevelTest.php
+++ b/tests/Unit/Connectors/Consumer/LowLevelTest.php
@@ -19,6 +19,7 @@ class LowLevelTest extends LaravelTestCase
             'consumer_group' => 'some-group',
             'topic' => 'some_topic',
             'offset_reset' => 'earliest',
+            'max_poll_interval_ms' => 900000,
             'offset' => 0,
             'partition' => 1,
         ]);


### PR DESCRIPTION
# Description

Adds support for config 'max.poll.interval.ms' on consumers. Now we could set a custom poll interval in ms, with the default value of 300000 ms (5 minutes).