### PR TITLE
feat: handling termination signal on consumer

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,21 +18,26 @@ jobs:
           - '8.1'
           - '8.2'
     env:
-      KAFKA_BROKER_CONNECTIONS: 'localhost:29092'
+      KAFKA_BROKER_CONNECTIONS: 'localhost:9092'
     services:
-      zookeeper:
-        image: bitnami/zookeeper
-        env:
-          ALLOW_ANONYMOUS_LOGIN: yes
       kafka:
-        image: bitnami/kafka
+        image: confluentinc/cp-kafka
         ports:
           - '9092:9092'
         env:
-          KAFKA_LISTENERS: 'PLAINTEXT://:9092'
-          KAFKA_CFG_ADVERTISED_LISTENERS: 'PLAINTEXT://localhost:9092'
-          KAFKA_CFG_ZOOKEEPER_CONNECT: 'zookeeper:2181'
-          ALLOW_PLAINTEXT_LISTENER: yes
+          KAFKA_NODE_ID: 1
+          KAFKA_PROCESS_ROLES: 'broker,controller'
+          KAFKA_CONTROLLER_QUORUM_VOTERS: '1@localhost:29093'
+          KAFKA_LISTENERS: 'PLAINTEXT://0.0.0.0:29092,CONTROLLER://0.0.0.0:29093,PLAINTEXT_HOST://0.0.0.0:9092'
+          KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092'
+          KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: 'CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT'
+          KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
+          KAFKA_INTER_BROKER_LISTENER_NAME: 'PLAINTEXT'
+          CLUSTER_ID: 'MkU3OEVBNTcwNTJENDM2Qk'
+          KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+          KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+          KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+          KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,7 +18,7 @@ jobs:
           - '8.1'
           - '8.2'
     env:
-      KAFKA_BROKER_CONNECTIONS: 'localhost:9092'
+      KAFKA_BROKER_CONNECTIONS: 'localhost:29092'
     services:
       zookeeper:
         image: bitnami/zookeeper

--- a/config/service.php
+++ b/config/service.php
@@ -19,7 +19,7 @@ return [
         'password' => 'PASSWORD',
     ],
     'broker' => [
-        'connections' => env('KAFKA_BROKER_CONNECTIONS', 'kafka:9092'),
+        'connections' => env('KAFKA_BROKER_CONNECTIONS', 'kafka:29092'),
         'auth' => [
             'type' => 'ssl', // ssl and none
             'ca' => storage_path('ca.pem'),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,17 +8,21 @@ services:
         depends_on:
             - kafka
 
-    zookeeper:
-        image: bitnami/zookeeper
-        environment:
-            - ALLOW_ANONYMOUS_LOGIN=yes
-
     kafka:
-        image: bitnami/kafka
-        depends_on:
-          - zookeeper
+        image: confluentinc/cp-kafka
+        ports:
+            - "9092:9092"
         environment:
-            - KAFKA_LISTENERS=PLAINTEXT://:9092
-            - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
-            - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
-            - ALLOW_PLAINTEXT_LISTENER=yes
+          KAFKA_NODE_ID: 1
+          KAFKA_PROCESS_ROLES: 'broker,controller'
+          KAFKA_CONTROLLER_QUORUM_VOTERS: '1@localhost:29093'
+          KAFKA_LISTENERS: 'PLAINTEXT://0.0.0.0:29092,CONTROLLER://0.0.0.0:29093,PLAINTEXT_HOST://0.0.0.0:9092'
+          KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092'
+          KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: 'CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT'
+          KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
+          KAFKA_INTER_BROKER_LISTENER_NAME: 'PLAINTEXT'
+          CLUSTER_ID: 'MkU3OEVBNTcwNTJENDM2Qk'
+          KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+          KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+          KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+          KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -1,6 +1,6 @@
 grumphp:
   git_hook_variables:
-    EXEC_GRUMPHP_COMMAND: 'docker-compose run --rm -e COLUMNS=$COLUMNS -e LINES=$LINES -e TERM=$TERM -T php'
+    EXEC_GRUMPHP_COMMAND: 'docker compose run --rm -e COLUMNS=$COLUMNS -e LINES=$LINES -e TERM=$TERM -T php'
   stop_on_failure: true
   process_timeout: 120
   ascii:

--- a/src/Console/ConsumerCommand.php
+++ b/src/Console/ConsumerCommand.php
@@ -6,9 +6,10 @@ use Illuminate\Console\Command as BaseCommand;
 use Metamorphosis\Connectors\Consumer\Config;
 use Metamorphosis\Connectors\Consumer\Factory;
 use Metamorphosis\Consumers\Runner;
+use Symfony\Component\Console\Command\SignalableCommandInterface;
 use Metamorphosis\TopicHandler\ConfigOptions\Consumer;
 
-class ConsumerCommand extends BaseCommand
+class ConsumerCommand extends BaseCommand implements SignalableCommandInterface
 {
     /**
      * @var {inheritdoc}
@@ -37,23 +38,48 @@ class ConsumerCommand extends BaseCommand
         {--config_name= : Change default name for laravel config file.}
         {--service_name= : Change default name for services config file.}';
 
+    private ?Runner $runner = null;
+    private ?Consumer $consumer = null;
+
     public function handle(Config $config): void
     {
-        $consumer = $config->make($this->option(), $this->argument());
+        $this->consumer = $config->make($this->option(), $this->argument());
 
-        $this->writeStartingConsumer($consumer);
+        $this->writeStartingConsumer();
 
-        $manager = Factory::make($consumer);
+        $manager = Factory::make($this->consumer);
 
-        $runner = app(Runner::class, compact('manager'));
-        $runner->run($this->option('times'));
+        $this->runner = app(Runner::class, compact('manager'));
+        $this->runner->run($this->option('times'));
     }
 
-    private function writeStartingConsumer(Consumer $consumer): void
+    public function getSubscribedSignals(): array
     {
-        $text = 'Starting consumer for topic: ' . $consumer->getTopicId() . PHP_EOL;
-        $text .= ' on consumer group: ' . $consumer->getConsumerGroup() . PHP_EOL;
-        $text .= 'Connecting in ' . $consumer->getBroker()->getConnections() . PHP_EOL;
+        return [SIGINT, SIGTERM];
+    }
+
+    public function handleSignal(int $signal): void
+    {
+        if (null === $this->runner) {
+            $this->error('Consumer is not running.');
+
+            return;
+        }
+
+        $this->info(
+            "Gracefully shutting down the consumer {$this->consumer?->getConsumerGroup()}" .
+            " from topic {$this->consumer?->getTopicId()} at connection {$this->consumer?->getBroker()->getConnections()}" .
+            " with signal {$signal}..."
+        );
+
+        $this->runner->shutdown();
+    }
+
+    private function writeStartingConsumer(): void
+    {
+        $text = 'Starting consumer for topic: ' . $this->consumer?->getTopicId() . PHP_EOL;
+        $text .= ' on consumer group: ' . $this->consumer?->getConsumerGroup() . PHP_EOL;
+        $text .= 'Connecting in ' . $this->consumer?->getBroker()->getConnections() . PHP_EOL;
         $text .= 'Running consumer..';
 
         $this->output->writeln($text);

--- a/src/Consumers/Runner.php
+++ b/src/Consumers/Runner.php
@@ -8,6 +8,8 @@ class Runner
 {
     private Manager $manager;
 
+    private bool $shuttingDown = false;
+
     public function __construct(Manager $manager)
     {
         $this->manager = $manager;
@@ -18,6 +20,9 @@ class Runner
         if ($times) {
             for ($i = 0; $i < $times; $i++) {
                 $this->manager->handleMessage();
+                if ($this->shuttingDown) {
+                    return;
+                }
             }
 
             return;
@@ -25,6 +30,14 @@ class Runner
 
         while (true) {
             $this->manager->handleMessage();
+            if ($this->shuttingDown) {
+                return;
+            }
         }
+    }
+
+    public function shutdown(): void
+    {
+        $this->shuttingDown = true;
     }
 }

--- a/tests/Integration/ConsumerTest.php
+++ b/tests/Integration/ConsumerTest.php
@@ -17,7 +17,7 @@ class ConsumerTest extends LaravelTestCase
     public function testItShouldSetup(): void
     {
         // Set
-        $connections = env('KAFKA_BROKER_CONNECTIONS', 'kafka:9092');
+        $connections = env('KAFKA_BROKER_CONNECTIONS', 'kafka:29092');
         $brokerOptions = new Broker($connections, new None());
         $consumerConfigOptions = new ConsumerConfigOptions(
             'single_consumer_test',

--- a/tests/Integration/ProducerTest.php
+++ b/tests/Integration/ProducerTest.php
@@ -206,7 +206,7 @@ class ProducerTest extends LaravelTestCase
 
     private function createProducerConfigOptions(string $topicId): ProducerConfigOptions
     {
-        $connections = env('KAFKA_BROKER_CONNECTIONS', 'kafka:9092');
+        $connections = env('KAFKA_BROKER_CONNECTIONS', 'kafka:29092');
         $broker = new Broker($connections, new None());
 
         return new ProducerConfigOptions(

--- a/tests/Integration/ProducerWithAvroTest.php
+++ b/tests/Integration/ProducerWithAvroTest.php
@@ -52,7 +52,7 @@ class ProducerWithAvroTest extends LaravelTestCase
                     'test' => [
                         'connections' => env(
                             'KAFKA_BROKER_CONNECTIONS',
-                            'kafka:9092'
+                            'kafka:29092'
                         ),
                     ],
                 ],
@@ -171,7 +171,7 @@ class ProducerWithAvroTest extends LaravelTestCase
 
     private function createProducerConfigOptions(string $topicId): ProducerConfigOptions
     {
-        $connections = env('KAFKA_BROKER_CONNECTIONS', 'kafka:9092');
+        $connections = env('KAFKA_BROKER_CONNECTIONS', 'kafka:29092');
         $broker = new Broker($connections, new None());
 
         return new ProducerConfigOptions(

--- a/tests/Integration/ProducerWithConfigOptionsTest.php
+++ b/tests/Integration/ProducerWithConfigOptionsTest.php
@@ -53,7 +53,7 @@ class ProducerWithConfigOptionsTest extends LaravelTestCase
 
     protected function haveAHandlerConfigured(): void
     {
-        $connections = env('KAFKA_BROKER_CONNECTIONS', 'kafka:9092');
+        $connections = env('KAFKA_BROKER_CONNECTIONS', 'kafka:29092');
         $broker = new Broker($connections, new None());
         $this->producerConfigOptions = new ProducerConfigOptions(
             'sale_order_override',

--- a/tests/Unit/Connectors/Consumer/FactoryTest.php
+++ b/tests/Unit/Connectors/Consumer/FactoryTest.php
@@ -61,7 +61,7 @@ class FactoryTest extends LaravelTestCase
     {
         parent::setUp();
 
-        $connections = env('KAFKA_BROKER_CONNECTIONS', 'kafka:9092');
+        $connections = env('KAFKA_BROKER_CONNECTIONS', 'kafka:29092');
         config([
             'kafka' => [
                 'brokers' => [

--- a/tests/Unit/Connectors/Producer/ConnectorTest.php
+++ b/tests/Unit/Connectors/Producer/ConnectorTest.php
@@ -29,7 +29,7 @@ class ConnectorTest extends LaravelTestCase
             m::mock(KafkaProducer::class)
         );
 
-        $connections = env('KAFKA_BROKER_CONNECTIONS', 'kafka:9092');
+        $connections = env('KAFKA_BROKER_CONNECTIONS', 'kafka:29092');
         $broker = new Broker($connections, new None());
         $producerConfigOptions = m::mock(ProducerConfigOptions::class);
 
@@ -80,7 +80,7 @@ class ConnectorTest extends LaravelTestCase
             m::mock(KafkaProducer::class)
         );
 
-        $connections = env('KAFKA_BROKER_CONNECTIONS', 'kafka:9092');
+        $connections = env('KAFKA_BROKER_CONNECTIONS', 'kafka:29092');
         $broker = new Broker($connections, new None());
         $producerConfigOptions = m::mock(ProducerConfigOptions::class);
 

--- a/tests/Unit/Console/ConsumerCommandTest.php
+++ b/tests/Unit/Console/ConsumerCommandTest.php
@@ -2,9 +2,16 @@
 
 namespace Tests\Unit\Console;
 
+use Illuminate\Console\OutputStyle;
+use Metamorphosis\Connectors\Consumer\Config;
+use Metamorphosis\Console\ConsumerCommand;
 use Metamorphosis\Consumers\Runner;
 use Metamorphosis\Exceptions\ConfigurationException;
 use Mockery as m;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
 use Tests\LaravelTestCase;
 use Tests\Unit\Dummies\ConsumerHandlerDummy;
 
@@ -130,6 +137,67 @@ class ConsumerCommandTest extends LaravelTestCase
             ->once();
 
         $this->artisan($command, $parameters);
+    }
+
+    public function testHandleSignalWhenConsumerIsNotRunning(): void
+    {
+        // Set
+        $command = new ConsumerCommand();
+        $output = m::mock(OutputStyle::class);
+        $command->setOutput($output);
+
+        // Expectations
+        $output->expects()
+            ->writeln('<error>Consumer is not running.</error>', 32)
+            ->andReturnNull();
+
+        // Actions
+        $command->handleSignal(SIGINT);
+    }
+
+    public function testHandleSignalGracefulShutdown(): void
+    {
+        // Set
+        $config = new Config();
+        $output = m::mock(OutputStyle::class);
+        $command = new ConsumerCommand();
+
+        $command->setOutput($output);
+
+        $inputDefinition = new InputDefinition([
+            new InputArgument('command', InputArgument::REQUIRED),
+            new InputArgument('topic', InputArgument::REQUIRED),
+            new InputOption('times'),
+        ]);
+
+        $command->setInput(
+            new ArrayInput(
+                [
+                    'command' => 'kafka:consume',
+                    'topic' => 'topic_key',
+                    '--times' => 1,
+                ],
+                $inputDefinition
+            ),
+        );
+
+        // Expectations
+        $output->expects()
+            ->writeln(
+                "Starting consumer for topic: topic_name\n on consumer group: default\nConnecting in test_kafka:6680\nRunning consumer.."
+            )
+            ->andReturnNull();
+
+        $output->expects()
+            ->writeln(
+                '<info>Gracefully shutting down the consumer default from topic topic_name at connection test_kafka:6680 with signal 15...</info>',
+                32
+            )
+            ->andReturnNull();
+
+        // Actions
+        $command->handle($config);
+        $command->handleSignal(SIGTERM);
     }
 
     protected function setUp(): void

--- a/tests/Unit/Consumers/RunnerTest.php
+++ b/tests/Unit/Consumers/RunnerTest.php
@@ -75,4 +75,27 @@ class RunnerTest extends LaravelTestCase
         // Actions
         $runner->run(3);
     }
+
+    public function testShouldHandleShutdown(): void
+    {
+        // Set
+        $manager = m::mock(Manager::class);
+        $runner = new Runner($manager);
+        $count = 0;
+
+        // Expectations
+        $manager->shouldReceive('handleMessage')
+            ->times(2)
+            ->andReturnUsing(function () use (&$count, $runner) {
+                if (1 === $count) {
+                    $runner->shutdown();
+                }
+                $count++;
+
+                return;
+            });
+
+        // Actions
+        $runner->run();
+    }
 }


### PR DESCRIPTION
## Descrição

Este PR introduz o suporte à captura de sinais de terminação do sistema (SIGTERM, SIGINT) no comando de console encarregado de processar tópicos do Kafka. O objetivo é garantir que o runner finalize a execução da mensagem atual antes de encerrar o processo, evitando o reprocessamento desnecessário ou a corrupção de dados.

Atualmente, ao receber um sinal de parada (comum durante deploys, reinicializações de pods ou escalonamento), o processo é encerrado imediatamente. Essa interrupção abrupta no meio de uma execução gera dois problemas principais:

- Inconsistência de Estado: Se o _runner_ for interrompido após uma escrita no banco de dados, mas antes de uma confirmação de offset ou de um log crítico, o sistema entra em estado inconsistente.

- Reprocessamento (_Duplicate Processing_): Independente da estratégia de _commit_ (manual ou automática), se o processo morre antes de registrar que aquela mensagem foi concluída, ela será lida novamente por outro _consumer_, gerando retrabalho e carga desnecessária.

## Observações

Foram encontradas algumas inconsistências no _build_ da aplicação exigindo algumas modificações:

- Migração de Imagens: Substituição das imagens Bitnami pelas imagens oficiais da Confluentinc no docker-compose.yml e no workflow do GitHub Actions.

- Remoção do ZooKeeper: O ambiente foi migrado para o modo KRaft (Kafka Raft), simplificando a arquitetura ao remover a necessidade de um cluster ZooKeeper separado.

- Configurações de Rede/Ports: Ajuste nas variáveis de ambiente do Kafka para suporte ao Controller e Broker no mesmo container (processo único de quorum).

## Links

https://www.baeldung.com/linux/sigint-and-other-termination-signals